### PR TITLE
URL regex: detect URL when HTLM tag before URL

### DIFF
--- a/dev/jquery.tweetParser.js
+++ b/dev/jquery.tweetParser.js
@@ -35,7 +35,7 @@
                 hashtagOnly, //hashtags on tweet
                 url, //url to hashtag search
             //regex
-                regexUrl = /(^|\s)((f|ht)tps?:\/\/([^ \t\r\n<]*[^ \t\r\n\<)*_,\.]))/g, //regex for urls
+                regexUrl = /(^|\s|>)((f|ht)tps?:\/\/([^ \t\r\n<]*[^ \t\r\n\<)*_,\.]))/g, //regex for urls
                 regexUser = /\B@([a-zA-Z0-9_]+)/g, //regex for @users
                 regexHashtag = /\B(#[á-úÁ-Úä-üÄ-Üa-zA-Z0-9_]+)/g; //regex for #hashtags
 


### PR DESCRIPTION
Hi,
In my previous commit I dealt with the case when there's an HTML tag after the URL but I forgot the case when there's an HTML tag before the URL..
(yes, I use this tweet parser with something else than just tweets ;))
Probably it could be relevant to also add punctuation ("." , ";" , "," , etc.) to the list. Not sure about that.
